### PR TITLE
fix: Add permissions to release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,8 @@ jobs:
   release:
     needs: build-release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
The `softprops/action-gh-release` action was failing with a `Resource not accessible by integration` error. This was because the `GITHUB_TOKEN` did not have the required permissions to create a release.

This commit adds the `permissions: contents: write` block to the `release` job to grant the necessary permissions.